### PR TITLE
Performance Improvements / Experiments

### DIFF
--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -8,7 +8,6 @@ import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.environment.DirectionalLight;
 import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
 import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
-import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder.VertexInfo;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
 import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.utils.Array;
@@ -20,7 +19,7 @@ public class MyGdxGame extends ApplicationAdapter {
     public CameraInputController camController;
     public Environment environment;
     public ModelBuilder modelBuilder;
-    MeshPartBuilder partBuilder;
+    public MeshPartBuilder partBuilder;
     public ModelInstance instance;
     public ModelBatch modelBatch;
     public Model model;
@@ -48,7 +47,7 @@ public class MyGdxGame extends ApplicationAdapter {
 	    cam = new PerspectiveCamera(50, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 	    cam.position.set(20f,20f,20f);
 	    cam.lookAt(0f,0f,0f);
-	    cam.near = 1f;
+	    cam.near = 0.1f;
 	    cam.far = 50f;
 	    cam.update();
 
@@ -73,26 +72,47 @@ public class MyGdxGame extends ApplicationAdapter {
         int q = 0;
         
         for(int i = 0; i < planet.tiles.size; i++) {
-			if(i%600 == 0){
+			if(i%1000 == 0){
 				partBuilder = modelBuilder.part("tile" + i, GL20.GL_TRIANGLES, VertexAttributes.Usage.Position | VertexAttributes.Usage.Normal | VertexAttributes.Usage.ColorPacked, new Material());
 				q++;
-			}for(int j = 0; j < planet.tiles.get(i).pts.size; j++) {
-                int k = j+1;
-                if(k == planet.tiles.get(i).pts.size) k = 0;
-                partBuilder.setColor(0.5f+0.5f*(float)Math.sin(q*Math.PI), 0.5f + 0.5f*(float)Math.cos((q)*Math.PI/2.0f), 0.5f - 0.5f*(float)Math.sin(q*Math.PI), 1.0f);
-
-				partBuilder.triangle(
-                                planet.tiles.get(i).centroid,
-                                planet.tiles.get(i).pts.get(j),
-                                planet.tiles.get(i).pts.get(k));
+			}
+            int numPts = planet.tiles.get(i).pts.size;
+            if (numPts == 6) {
+                partBuilder.setColor(0.5f + 0.5f * (float) Math.sin(q * Math.PI), 0.5f + 0.5f * (float) Math.cos((q) * Math.PI / 2.0f), 0.5f - 0.5f * (float) Math.sin(q * Math.PI), 1.0f);
+                partBuilder.rect(
+                        planet.tiles.get(i).pts.get(0),
+                        planet.tiles.get(i).pts.get(1),
+                        planet.tiles.get(i).pts.get(3),
+                        planet.tiles.get(i).pts.get(4),
+                        planet.tiles.get(i).centroid
+                );
+                partBuilder.triangle(
+                        planet.tiles.get(i).pts.get(0),
+                        planet.tiles.get(i).pts.get(4),
+                        planet.tiles.get(i).pts.get(5)
+                );
+                partBuilder.triangle(
+                        planet.tiles.get(i).pts.get(1),
+                        planet.tiles.get(i).pts.get(2),
+                        planet.tiles.get(i).pts.get(3)
+                );
+            } else {
+                for (int j = 0; j < numPts; j++) {
+                    int k = j + 1;
+                    if (k == numPts) k = 0;
+                    partBuilder.setColor(0.5f + 0.5f * (float) Math.sin(q * Math.PI), 0.5f + 0.5f * (float) Math.cos((q) * Math.PI / 2.0f), 0.5f - 0.5f * (float) Math.sin(q * Math.PI), 1.0f);
+                    partBuilder.triangle(
+                            planet.tiles.get(i).centroid,
+                            planet.tiles.get(i).pts.get(j),
+                            planet.tiles.get(i).pts.get(k));
+                }
             }
         }
 
 
-        model = modelBuilder.end();         // The model is then assigned
+        model = modelBuilder.end();
         endTime = System.currentTimeMillis();
         System.out.println("Build Time: " + (endTime - startTime) + " ms");
-        // Create a new instance of the model
         instance = new ModelInstance(model, 0, 0 ,0);
 
         camController = new CameraInputController(cam);

--- a/core/src/com/mygdx/game/Planet.java
+++ b/core/src/com/mygdx/game/Planet.java
@@ -95,7 +95,6 @@ public class Planet{
     public void setFaceNeighbors() {
         for(int i = 0; i < faces.size; i++) {
             for(int j = i+1; j < faces.size; j++) {
-                if(i == j) continue;
                 if(faces.get(i).nbrs.size == 3) break;
                 if(faces.get(i).testNeighbor(faces.get(j))) {
 //                    System.out.println(i + " and " + j + " are neighbors");
@@ -137,40 +136,45 @@ public class Planet{
 					else { q1 = newPoints.get(newPoints.indexOf(q1, false)); }
 				if(!newPoints.contains(q2, false)){ newPoints.add(q2); }
 					else { q2 = newPoints.get(newPoints.indexOf(q2, false)); }
-					
-                newFaces.addAll(
-                        new Face(p0, q0, q2),
-                        new Face(p1, q1, q0),
-                        new Face(p2, q2, q1),
-                        new Face(q0, q1, q2)
-                );
-                
+
+				Face f0 = new Face(p0, q0, q2);
+				Face f1 = new Face(p1, q1, q0);
+				Face f2 = new Face(p2, q2, q1);
+				Face f3 = new Face(q0, q1, q2);
+				if(i == degree-1) {
+                    f3.addNbr(f0);
+                    f3.addNbr(f1);
+                    f3.addNbr(f2);
+                    f0.addNbr(f3);
+                    f1.addNbr(f3);
+                    f2.addNbr(f3);
+                }
+				newFaces.addAll(f0, f1, f2, f3);
+
             }
             // set faces = newFaces
             points.addAll(newPoints);
 			faces.clear();
-            faces.ensureCapacity(newFaces.size - faces.size);
+            faces.ensureCapacity(newFaces.size);
             faces.addAll(newFaces);
         }
     }
 
     public void convertToDual() {
-        Array<Vector3> pts = new Array<Vector3>();             // Array for Tile points
+        Array<Vector3> pts = new Array<Vector3>();  // Array for Tile points
         Face curr;
-        boolean isTile;
         for(Face face : faces) {
             curr = face;
-            isTile = false;
 
-            Vector3 p1 = curr.pts[0];                       // Tile centroid
+            Vector3 p1 = curr.pts[0];         // Tile centroid
             if(face.ptsUsedAsTileCentroid.contains(p1, false))
                 p1 = curr.pts[1];
             if(face.ptsUsedAsTileCentroid.contains(p1, false))
                 continue;
 
             do {
-                pts.add(curr.centroid);                  // add current centroid
-                Vector3 p2 = curr.pts[getCwPt(curr, p1)];   // CCW point
+                pts.add(curr.centroid);                     // add current centroid
+                Vector3 p2 = curr.pts[getCwPt(curr, p1)];   // CW point
 
                 for (Face nbr : curr.nbrs) {                // find CCW neighbor
                     int count = 0;


### PR DESCRIPTION
Hexagonal tiles are built using 1 rectangle and 2 triangles instead of 6 triangles, which reduced build time by 40%.

Adding face neighbors during final subdivision sets all nbrs of 25% of tiles and 1/3 of nbrs in the other 75%, but for some reason doesn't reduce generation time.